### PR TITLE
Change method of walking of the zombies

### DIFF
--- a/zombies.lua
+++ b/zombies.lua
@@ -154,7 +154,7 @@ Citizen.CreateThread(function()
 	            end
 
 	            if Distance <= DistanceTarget and not IsPedInAnyVehicle(PlayerPedId(), false) then
-	                TaskGoStraightToCoord(Zombie, PlayerCoords.x, PlayerCoords.y, PlayerCoords.z, 2.0, -1, 0.0, 0.0)
+	                TaskGoToEntity(Zombie, GetPlayerPed(-1), -1, 0.0, 2.0, 1073741824, 0)
 	            end
 
 	            if Distance <= 1.3 then


### PR DESCRIPTION
change the Native to TaskGoToEntity and the zombies now walk more precise and also around the most props or entities instead of walking a straight path to the player.